### PR TITLE
Automated release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build project
         run: cargo build --target x86_64-pc-windows-gnu --release && cargo build --release
       - name: Publish release
-        uses: uses: ghalactic/github-release-from-tag@v5
+        uses: ghalactic/github-release-from-tag@v5
         with:
           assets: |
             - path: target/release/client

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,8 @@ jobs:
       - name: Publish release
         uses: ghalactic/github-release-from-tag@v5
         with:
+          generateReleaseNotes: "true"
+          prerelease: "false"
           assets: |
             - path: target/release/client
               name: client-linux

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,27 @@
+name: Release
+on:
+  push:
+    tags:
+      - '*'
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+        contents: write
+    steps:
+      - name: Clone project
+        uses: actions/checkout@v4
+      - name: Setup Rust
+        run: |
+          rustup default stable
+          rustup target add x86_64-pc-windows-gnu
+      - name: Build project
+        run: cargo build --target x86_64-pc-windows-gnu --release && cargo build --release
+      - name: Publish release
+        uses: uses: ghalactic/github-release-from-tag@v5
+        with:
+          assets: |
+            - path: target/release/client
+              name: client-linux
+            - path: target/x86_64-pc-windows-gnu/release/client.exe
+              name: client-windows.exe

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,8 @@ jobs:
     steps:
       - name: Clone project
         uses: actions/checkout@v4
+      - name: Setup MinGW
+        uses: egor-tensin/setup-mingw@v2.2.0
       - name: Setup Rust
         run: |
           rustup default stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Setup MinGW
         uses: egor-tensin/setup-mingw@v2.2.0
+      - name: Setup GCC
+        uses: egor-tensin/setup-gcc@v1.3
       - name: Setup Rust
         run: |
           rustup default stable


### PR DESCRIPTION
To make it work create tag (`git tag -a versionname` in cli git), name it and add some description. Action will build binaries for linux and windows, and then publish release with them.