### PR TITLE
Use `javaw` on Windows and refactor settings

### DIFF
--- a/crates/client/src/collections.rs
+++ b/crates/client/src/collections.rs
@@ -53,9 +53,9 @@ impl<'c> TasksCollection<'c> for AssetsCollection {
     }
 }
 
-pub struct JavaCollection;
+pub struct JavaDownloadingCollection;
 
-impl<'c> TasksCollection<'c> for JavaCollection {
+impl<'c> TasksCollection<'c> for JavaDownloadingCollection {
     type Context = ();
 
     type Target = ();
@@ -67,7 +67,9 @@ impl<'c> TasksCollection<'c> for JavaCollection {
     }
 
     fn handle(_context: Self::Context) -> Handler<'c, Self::Target> {
-        Handler::new(|()| ())
+        Handler::new(|()| {
+            toasts::add(|toasts| toasts.success("Successfully downloaded Java"));
+        })
     }
 }
 

--- a/crates/client/src/states.rs
+++ b/crates/client/src/states.rs
@@ -1,16 +1,17 @@
 use std::path::PathBuf;
 
-use eframe::egui::Context;
+use eframe::egui::{Context, Ui};
 use egui_task_manager::{Caller, Task, TaskManager};
 use nomi_core::{
     downloads::{java::JavaDownloader, progress::MappedSender, traits::Downloader},
     fs::read_toml_config_sync,
+    repository::java_runner::JavaRunner,
     DOT_NOMI_JAVA_DIR, DOT_NOMI_JAVA_EXECUTABLE, DOT_NOMI_SETTINGS_CONFIG,
 };
 use tracing::info;
 
 use crate::{
-    collections::JavaCollection,
+    collections::JavaDownloadingCollection,
     errors_pool::ErrorPoolExt,
     views::{
         add_tab_menu::TabsState,
@@ -92,6 +93,12 @@ impl JavaState {
         });
 
         let task = Task::new("Java downloading", caller);
-        manager.push_task::<JavaCollection>(task);
+        manager.push_task::<JavaDownloadingCollection>(task);
     }
+}
+
+pub fn download_java_and_update_config(ui: &mut Ui, manager: &mut TaskManager, java_state: &mut JavaState, settings_state: &mut SettingsState) {
+    java_state.download_java(manager, ui.ctx().clone());
+    settings_state.java = JavaRunner::path(PathBuf::from(DOT_NOMI_JAVA_EXECUTABLE));
+    settings_state.update_config();
 }

--- a/crates/nomi-core/src/consts.rs
+++ b/crates/nomi-core/src/consts.rs
@@ -4,7 +4,10 @@ pub const DOT_NOMI_CONFIGS_DIR: &str = "./.nomi/configs";
 pub const DOT_NOMI_SETTINGS_CONFIG: &str = "./.nomi/configs/Settings.toml";
 pub const DOT_NOMI_LOGS_DIR: &str = "./.nomi/logs";
 pub const DOT_NOMI_JAVA_DIR: &str = "./.nomi/java";
+#[cfg(not(windows))]
 pub const DOT_NOMI_JAVA_EXECUTABLE: &str = "./.nomi/java/jdk-22.0.1/bin/java";
+#[cfg(windows)]
+pub const DOT_NOMI_JAVA_EXECUTABLE: &str = "./.nomi/java/jdk-22.0.1/bin/javaw.exe";
 pub const DOT_NOMI_DATA_PACKS_DIR: &str = "./.nomi/datapacks";
 
 pub const LIBRARIES_DIR: &str = "./libraries";

--- a/crates/nomi-core/src/repository/java_runner.rs
+++ b/crates/nomi-core/src/repository/java_runner.rs
@@ -14,7 +14,8 @@ pub enum JavaRunner {
 impl JavaRunner {
     pub fn from_environment() -> Self {
         if std::env::var("PATH").is_ok_and(|path| path.contains("java")) {
-            Self::command("java")
+            let command = if cfg!(windows) { "javaw" } else { "java" };
+            Self::command(command)
         } else {
             Self::path(DOT_NOMI_JAVA_EXECUTABLE.into())
         }

--- a/crates/nomi-core/src/repository/username.rs
+++ b/crates/nomi-core/src/repository/username.rs
@@ -1,3 +1,5 @@
+use std::sync::LazyLock;
+
 use regex::Regex;
 use serde::{de::Visitor, Deserialize, Serialize};
 use thiserror::Error;
@@ -62,9 +64,10 @@ pub enum ValidationError {
 
 impl Username {
     pub fn new(s: impl Into<String>) -> anyhow::Result<Self> {
+        static REGEX: LazyLock<Regex> = LazyLock::new(|| Regex::new(r"^[a-zA-Z0-9_]{3,16}$").unwrap());
+
         let s = s.into();
-        let re = Regex::new(r"^[a-zA-Z0-9_]{3,16}$")?;
-        match re.captures(&s) {
+        match REGEX.captures(&s) {
             Some(_) => Ok(Username(s)),
             None => Err(ValidationError::InvalidUsername.into()),
         }


### PR DESCRIPTION
- Now uses `javaw` on Windows
- Removes Utils section from the settings.
- Adds new menus to the top bar, including: Utils, Download